### PR TITLE
Fix build issues and default python version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ ADD https://bootstrap.pypa.io/get-pip.py /tmp/get-pip.py
 ADD https://bootstrap.pypa.io/2.6/get-pip.py /tmp/get-pip2.6.py
 
 COPY files/requirements.sh /tmp/
+COPY files/early-requirements.txt /tmp/
 COPY requirements/*.txt /tmp/requirements/
 COPY freeze/*.txt /tmp/freeze/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,5 +75,5 @@ COPY freeze/*.txt /tmp/freeze/
 RUN /tmp/requirements.sh 2.6
 RUN /tmp/requirements.sh 2.7
 RUN /tmp/requirements.sh 3.5
-RUN /tmp/requirements.sh 3.6
 RUN /tmp/requirements.sh 3.7
+RUN /tmp/requirements.sh 3.6

--- a/files/early-requirements.txt
+++ b/files/early-requirements.txt
@@ -1,0 +1,1 @@
+pycparser  # required to install PyNaCl on Python 2.6

--- a/files/requirements.sh
+++ b/files/requirements.sh
@@ -6,16 +6,21 @@ echo "==> Selecting requirements for python ${python_version} ..."
 
 freeze_dir="$(dirname "$0")/freeze"
 requirements_dir="$(dirname "$0")/requirements"
-constraints="${requirements_dir}/constraints.txt"
+
+version_requirements=("/tmp/early-requirements.txt")
 
 if [ "$(ls "${freeze_dir}")" ]; then
     echo "Using requirements directory: ${freeze_dir}"
     cd "${freeze_dir}"
 
-    version_requirements=("${python_version}.txt")
+    constraints="${python_version}.txt"
+
+    version_requirements+=("${python_version}.txt")
 else
     echo "Using requirements directory: ${requirements_dir}"
     cd "${requirements_dir}"
+
+    constraints="${requirements_dir}/constraints.txt"
 
     requirements=()
 
@@ -24,8 +29,6 @@ else
             requirements+=("${requirement}")
         fi
     done
-
-    version_requirements=()
 
     for requirement in "${requirements[@]}"; do
         case "${python_version}" in


### PR DESCRIPTION
Fix build issues and default python version:

* The default pip python version now matches the default python (3.6 instead of 3.7).
* Requirements installation on Python 2.6 no longer fails during PyNaCl installation.
