### PR TITLE
Update requirements and freeze.

### DIFF
--- a/freeze/2.6.txt
+++ b/freeze/2.6.txt
@@ -6,8 +6,8 @@ asn1crypto==0.24.0
 Babel==2.5.3
 bcrypt==3.1.4
 boto==2.49.0
-boto3==1.9.94
-botocore==1.12.94
+boto3==1.9.96
+botocore==1.12.96
 certifi==2018.11.29
 cffi==1.12.0
 chardet==3.0.4

--- a/freeze/2.7.txt
+++ b/freeze/2.7.txt
@@ -39,8 +39,8 @@ azure-storage==0.35.1
 Babel==2.6.0
 bcrypt==3.1.6
 boto==2.49.0
-boto3==1.9.94
-botocore==1.12.94
+boto3==1.9.96
+botocore==1.12.96
 cachetools==3.1.0
 certifi==2018.11.29
 cffi==1.12.0
@@ -78,7 +78,7 @@ junit-xml==1.8
 jxmlease==1.0.1
 knack==0.3.3
 kubernetes==8.0.1
-linode-api4==2.0.0
+linode-api4==2.0.1
 linode-python==1.1.1
 lxml==4.3.1
 MarkupSafe==1.1.0
@@ -95,7 +95,7 @@ netifaces==0.10.9
 nose==1.3.7
 ntlm-auth==1.2.0
 oauthlib==3.0.1
-openshift==0.8.5
+openshift==0.8.6
 oslo.config==6.8.0
 oslo.context==2.22.0
 oslo.i18n==3.23.0
@@ -126,7 +126,7 @@ PyNaCl==1.3.0
 pyone==1.1.9
 pyOpenSSL==19.0.0
 pyparsing==2.3.1
-pytest==3.9.3
+pytest==4.2.1
 pytest-forked==1.0.2
 pytest-mock==1.10.1
 pytest-xdist==1.26.1

--- a/freeze/3.5.txt
+++ b/freeze/3.5.txt
@@ -40,8 +40,8 @@ azure-storage==0.35.1
 Babel==2.6.0
 bcrypt==3.1.6
 boto==2.49.0
-boto3==1.9.94
-botocore==1.12.94
+boto3==1.9.96
+botocore==1.12.96
 cachetools==3.1.0
 certifi==2018.11.29
 cffi==1.12.0
@@ -79,7 +79,7 @@ jxmlease==1.0.1
 knack==0.3.3
 kubernetes==8.0.1
 lazy-object-proxy==1.3.1
-linode-api4==2.0.0
+linode-api4==2.0.1
 linode-python==1.1.1
 lxml==4.3.1
 MarkupSafe==1.1.0
@@ -97,7 +97,7 @@ netifaces==0.10.9
 nose==1.3.7
 ntlm-auth==1.2.0
 oauthlib==3.0.1
-openshift==0.8.5
+openshift==0.8.6
 oslo.config==6.8.0
 oslo.context==2.22.0
 oslo.i18n==3.23.0
@@ -129,7 +129,7 @@ PyNaCl==1.3.0
 pyone==1.1.9
 pyOpenSSL==19.0.0
 pyparsing==2.3.1
-pytest==3.9.3
+pytest==4.2.1
 pytest-forked==1.0.2
 pytest-mock==1.10.1
 pytest-xdist==1.26.1

--- a/freeze/3.6.txt
+++ b/freeze/3.6.txt
@@ -40,8 +40,8 @@ azure-storage==0.35.1
 Babel==2.6.0
 bcrypt==3.1.6
 boto==2.49.0
-boto3==1.9.94
-botocore==1.12.94
+boto3==1.9.96
+botocore==1.12.96
 cachetools==3.1.0
 certifi==2018.11.29
 cffi==1.12.0
@@ -79,7 +79,7 @@ jxmlease==1.0.1
 knack==0.3.3
 kubernetes==8.0.1
 lazy-object-proxy==1.3.1
-linode-api4==2.0.0
+linode-api4==2.0.1
 linode-python==1.1.1
 lxml==4.3.1
 MarkupSafe==1.1.0
@@ -97,7 +97,7 @@ netifaces==0.10.9
 nose==1.3.7
 ntlm-auth==1.2.0
 oauthlib==3.0.1
-openshift==0.8.5
+openshift==0.8.6
 oslo.config==6.8.0
 oslo.context==2.22.0
 oslo.i18n==3.23.0
@@ -128,7 +128,7 @@ PyNaCl==1.3.0
 pyone==1.1.9
 pyOpenSSL==19.0.0
 pyparsing==2.3.1
-pytest==3.9.3
+pytest==4.2.1
 pytest-forked==1.0.2
 pytest-mock==1.10.1
 pytest-xdist==1.26.1

--- a/freeze/3.7.txt
+++ b/freeze/3.7.txt
@@ -40,8 +40,8 @@ azure-storage==0.35.1
 Babel==2.6.0
 bcrypt==3.1.6
 boto==2.49.0
-boto3==1.9.94
-botocore==1.12.94
+boto3==1.9.96
+botocore==1.12.96
 cachetools==3.1.0
 certifi==2018.11.29
 cffi==1.12.0
@@ -79,7 +79,7 @@ jxmlease==1.0.1
 knack==0.3.3
 kubernetes==8.0.1
 lazy-object-proxy==1.3.1
-linode-api4==2.0.0
+linode-api4==2.0.1
 linode-python==1.1.1
 lxml==4.3.1
 MarkupSafe==1.1.0
@@ -97,7 +97,7 @@ netifaces==0.10.9
 nose==1.3.7
 ntlm-auth==1.2.0
 oauthlib==3.0.1
-openshift==0.8.5
+openshift==0.8.6
 oslo.config==6.8.0
 oslo.context==2.22.0
 oslo.i18n==3.23.0
@@ -128,7 +128,7 @@ PyNaCl==1.3.0
 pyone==1.1.9
 pyOpenSSL==19.0.0
 pyparsing==2.3.1
-pytest==3.9.3
+pytest==4.2.1
 pytest-forked==1.0.2
 pytest-mock==1.10.1
 pytest-xdist==1.26.1

--- a/freeze/3.8.txt
+++ b/freeze/3.8.txt
@@ -40,8 +40,8 @@ azure-storage==0.35.1
 Babel==2.6.0
 bcrypt==3.1.6
 boto==2.49.0
-boto3==1.9.94
-botocore==1.12.94
+boto3==1.9.96
+botocore==1.12.96
 cachetools==3.1.0
 certifi==2018.11.29
 cffi==1.12.0
@@ -79,7 +79,7 @@ jxmlease==1.0.1
 knack==0.3.3
 kubernetes==8.0.1
 lazy-object-proxy==1.3.1
-linode-api4==2.0.0
+linode-api4==2.0.1
 linode-python==1.1.1
 lxml==4.3.1
 MarkupSafe==1.1.0
@@ -97,7 +97,7 @@ netifaces==0.10.9
 nose==1.3.7
 ntlm-auth==1.2.0
 oauthlib==3.0.1
-openshift==0.8.5
+openshift==0.8.6
 oslo.config==6.8.0
 oslo.context==2.22.0
 oslo.i18n==3.23.0
@@ -128,7 +128,7 @@ PyNaCl==1.3.0
 pyone==1.1.9
 pyOpenSSL==19.0.0
 pyparsing==2.3.1
-pytest==3.9.3
+pytest==4.2.1
 pytest-forked==1.0.2
 pytest-mock==1.10.1
 pytest-xdist==1.26.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,7 +11,7 @@ ncclient >= 0.5.2 # Need features added in 0.5.2 and greater
 idna < 2.6 # requests requires idna < 2.6, but cryptography will cause the latest version to be installed instead
 paramiko < 2.4.0 ; python_version < '2.7' # paramiko 2.4.0 drops support for python 2.6
 pytest < 3.3.0 ; python_version < '2.7' # pytest 3.3.0 drops support for python 2.6
-pytest < 3.10.0 ; python_version >= '2.7' # pytest 3.10.0+ causes some tests to crash
+pytest < 5.0.0 ; python_version == '2.7' # pytest 5.0.0 and later will no longer support python 2.7
 pytest-forked < 1.0.2 ; python_version < '2.7' # pytest-forked 1.0.2 and later require python 2.7 or later
 pytest-forked >= 1.0.2 ; python_version >= '2.7' # pytest-forked before 1.0.2 does not work with pytest 4.2.0+ (which requires python 2.7+)
 ntlm-auth >= 1.0.6 # message encryption support


### PR DESCRIPTION
Update requirements and freeze.

The most notable update is for pytest 3.9.3 -> 4.2.1 on Python 2.7 and later.