### PR TITLE
add libvirt-dev in the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update -y && \
     python3.6-dev \
     python3.7-dev \
     shellcheck \
+    libvirt-dev \
     && \
     apt-get clean
 


### PR DESCRIPTION
libvirt-python package depends on libvirt-dev. By adding this new
package, we can build the Python library and simplify the creation of
unit-tests for the virt_net[1], virt_pool and virt modules. In addition,
an effort is ongoing to build better libvirt modules[2], it may also benefit
from the availablity of the libvirt-python package in the base image.

[1]: https://github.com/ansible/ansible/pull/53276
[2]: https://github.com/ansible/ansible/issues/27905