### PR TITLE
Add custom PSSA rule and include pypsrp in container

### DIFF
--- a/requirements/sanity.ps1
+++ b/requirements/sanity.ps1
@@ -6,3 +6,6 @@ $ErrorActionPreference = "Stop"
 
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.16.1
+
+# Used to setup the PSCustomUseLiteralPath rule for PSSA
+Install-Module -Name PSSA-PSCustomUseLiteralPath -RequiredVersion 0.1.1

--- a/requirements/windows-integration.txt
+++ b/requirements/windows-integration.txt
@@ -5,5 +5,6 @@ paramiko
 ntlm-auth
 requests-ntlm
 requests-credssp
+pypsrp
 pywinrm[credssp]
 pyyaml


### PR DESCRIPTION
Include pypsrp in the windows-integration requires so we can start to run it on one of the Windows hosts.

Also include the `PSSA-PSCustomUseLiteralPath` module for use in our pslint testing. This is subject to https://github.com/ansible/community/issues/420#issuecomment-474200255