### PR TITLE
Update to Python 3.8.0b2

### DIFF
--- a/files/python3.8.0b2
+++ b/files/python3.8.0b2
@@ -3,4 +3,4 @@ prefer_openssl11
 export PYTHON_BUILD_CONFIGURE_WITH_OPENSSL=1
 install_package "openssl-1.1.0j" "https://www.openssl.org/source/openssl-1.1.0j.tar.gz#31bec6c203ce1a8e93d5994f4ed304c63ccf07676118b6634edded12ad1b3246" mac_openssl --if has_broken_mac_openssl
 install_package "readline-8.0" "https://ftpmirror.gnu.org/readline/readline-8.0.tar.gz#e339f51971478d369f8a053a330a190781acb9864cf4c541060f12078948e461" mac_readline --if has_broken_mac_readline
-install_package "Python-3.8.0b1" "https://www.python.org/ftp/python/3.8.0/Python-3.8.0b1.tgz#adf4f185730086da685599056483a81a3e7985df61033d4a1a900f58dd0cb7c6" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip
+install_package "Python-3.8.0b2" "https://www.python.org/ftp/python/3.8.0/Python-3.8.0b2.tgz#c8bb05fe0ade345d373c31c1b09840ee765390f1b78b30a16b850fdcba2a2776" ldflags_dirs standard verify_py38 copy_python_gdb ensurepip

--- a/freeze/3.8.txt
+++ b/freeze/3.8.txt
@@ -85,7 +85,7 @@ kubernetes==8.0.1
 lazy-object-proxy==1.3.1
 linode-api4==2.1.0
 linode-python==1.1.1
-lxml==4.3.4
+lxml==4.3.3
 MarkupSafe==1.1.1
 mccabe==0.6.1
 mock==3.0.5
@@ -143,7 +143,7 @@ python-string-utils==0.6.0
 pytz==2019.1
 pyvmomi==6.7.1.2018.12
 pywinrm==0.3.0
-PyYAML==5.1.1
+PyYAML==5.1.0
 redis==3.2.1
 requests==2.22.0
 requests-credssp==1.0.2
@@ -152,7 +152,7 @@ requests-oauthlib==1.2.0
 rfc3986==1.3.2
 rsa==4.0
 rstcheck==3.3.1
-ruamel.yaml==0.15.97
+ruamel.yaml==0.15.96
 s3transfer==0.2.1
 scp==0.13.2
 selectors2==2.0.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -16,10 +16,12 @@ pytest < 3.3.0 ; python_version < '2.7' # pytest 3.3.0 drops support for python 
 pytest < 5.0.0 ; python_version == '2.7' # pytest 5.0.0 and later will no longer support python 2.7
 pytest-forked < 1.0.2 ; python_version < '2.7' # pytest-forked 1.0.2 and later require python 2.7 or later
 pytest-forked >= 1.0.2 ; python_version >= '2.7' # pytest-forked before 1.0.2 does not work with pytest 4.2.0+ (which requires python 2.7+)
+pyyaml < 5.1.1 ; python_version >= '3.8' # This is required for >= 3.8.0b2 due to a change it Cython. It can be removed once these libraries update to Cython >= 0.29.11.
 ntlm-auth >= 1.3.0 # message encryption support using cryptography
 requests < 2.20.0 ; python_version < '2.7' # requests 2.20.0 drops support for python 2.6
 requests-ntlm >= 1.1.0 # message encryption support
 requests-credssp >= 0.1.0 # message encryption support
+ruamel.yaml < 0.15.97 ; python_version >= '3.8' # This is required for >= 3.8.0b2 due to a change it Cython. It can be removed once these libraries update to Cython >= 0.29.11.
 voluptuous >= 0.11.0 # Schema recursion via Self
 openshift >= 0.6.2 # merge_type support
 virtualenv < 16.0.0 ; python_version < '2.7' # virtualenv 16.0.0 and later require python 2.7 or later
@@ -31,6 +33,7 @@ mock >= 2.0.0 # needed for features backported from Python 3.6 unittest.mock (as
 pytest-mock >= 1.4.0 # needed for mock_use_standalone_module pytest option
 xmltodict < 0.12.0 ; python_version < '2.7' # xmltodict 0.12.0 and later require python 2.7 or later
 lxml < 4.3.0 ; python_version < '2.7' # lxml 4.3.0 and later require python 2.7 or later
+lxml < 4.3.4 ; python_version >= '3.8' # This is required for >= 3.8.0b2 due to a change it Cython. It can be removed once these libraries update to Cython >= 0.29.11.
 pyvmomi < 6.0.0 ; python_version < '2.7' # pyvmomi 6.0.0 and later require python 2.7 or later
 pyone == 1.1.9 # newer versions do not pass current integration tests
 botocore >= 1.10.0 # adds support for the following AWS services: secretsmanager, fms, and acm-pca


### PR DESCRIPTION
In Python 3.8.0b2, a [breaking change to Cython was reverted](https://github.com/python/cpython/pull/13959). The packages we use that had problems with this change, `lxml`, `pyyaml`, and `ruamel.yaml`, hav not yet released versions that include the Cython 0.29.11. Reverting to the last released version of these three libraries is needed for a successful build on Python 3.8.0b2.

`pip`'s [Environment Marker](https://www.python.org/dev/peps/pep-0508/#environment-markers) only provides major and minor version (specifically, `platform.python_version()[:3]`) and omits the beta information. This means we cannot target a specific beta version in our constraints file.