### PR TITLE
bump pip version to ensure we can install vsphere SDK

### DIFF
--- a/files/requirements.sh
+++ b/files/requirements.sh
@@ -52,7 +52,7 @@ fi
 echo "Using constraints file: ${constraints}"
 
 get_pip_tmp="/tmp/get-pip.py"
-pip_version="19.0.2"
+pip_version="19.2.3"
 
 if [[ "${python_version}" = "2.6" ]]; then
     get_pip_tmp="/tmp/get-pip2.6.py"


### PR DESCRIPTION
Vsphere automation SDK cannot be installed with pip 19.0.2:

```
(...)
02:27 Collecting git+https://github.com/vmware/vsphere-automation-sdk-python.git (from -r /root/ansible/test/lib/ansible_test/_data/requirements/integration.cloud.vcenter.txt (line 2))
02:27   Cloning https://github.com/vmware/vsphere-automation-sdk-python.git to /tmp/pip-req-build-pm27t16b
02:33 Requirement already satisfied: pyvmomi in /usr/local/lib/python3.6/dist-packages (from -r /root/ansible/test/lib/ansible_test/_data/requirements/integration.cloud.vcenter.txt (line 1)) (6.7.1.2018.12)
02:33 Requirement already satisfied: lxml>=4.3.0 in /usr/local/lib/python3.6/dist-packages (from vSphere-Automation-SDK==1.4.0->-r /root/ansible/test/lib/ansible_test/_data/requirements/integration.cloud.vcenter.txt (line 2)) (4.4.0)
02:33 Processing ./\\localhost/tmp/pip-req-build-pm27t16b/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl
02:33 Could not install packages due to an EnvironmentError: [Errno 2] No such file or directory: '/root/ansible/\\\\localhost/tmp/pip-req-build-pm27t16b/lib/vapi-runtime/vapi_runtime-2.12.0-py2.py3-none-any.whl'
```

See: https://github.com/ansible/ansible/pull/62022