### PR TITLE
Use configparser 4.0.2 because 4.0.1 is gone.

### DIFF
--- a/freeze/2.7.txt
+++ b/freeze/2.7.txt
@@ -50,7 +50,7 @@ certifi==2019.6.16
 cffi==1.12.3
 chardet==3.0.4
 colorama==0.4.1
-configparser==4.0.1
+configparser==4.0.2
 contextlib2==0.5.5
 coverage==4.5.4
 cryptography==2.7


### PR DESCRIPTION
See https://github.com/jaraco/configparser/issues/46