### PR TITLE
Reduce the size of pwsh in the container

### DIFF
--- a/requirements/sanity.ps1
+++ b/requirements/sanity.ps1
@@ -3,9 +3,17 @@
 
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
+$ProgressPreference = 'SilentlyContinue'
 
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.18.0 -Scope CurrentUser
+
+# PSScriptAnalyzer contain lots of json files for the UseCompatibleCommands check. We don't use this rule so by
+# removing the contents we can save 200MB in the docker image (or more in the future).
+# https://github.com/PowerShell/PSScriptAnalyzer/blob/master/RuleDocumentation/UseCompatibleCommands.md
+$pssaPath = (Get-Module -ListAvailable -Name PSScriptAnalyzer).ModuleBase
+$compatPath = Join-Path -Path $pssaPath -ChildPath compatibility_profiles -AdditionalChildPath '*'
+Remove-Item -Path $compatPath -Recurse -Force
 
 # Installed the PSCustomUseLiteralPath rule
 Install-Module -Name PSSA-PSCustomUseLiteralPath -RequiredVersion 0.1.1 -Scope CurrentUser


### PR DESCRIPTION
Makes a few changes to slim down the container size when it comes to pwsh

* Remove PSScriptAnalyzer compatibility packs that aren't used in our sanity tests - saves ~200MB
* Don't install the .NET SDK, it isn't needed and just adds more space
* Pin PowerShell to a specific version, doesn't save space but it adds repeatability to the build

In total before these changes the image size was `2.66GB`, now it is `1.7GB`.

Also adds a tweak that allows these containers to be built with podman.