### PR TITLE
Copy ps sanity from anisble/ansible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN apt-get update -y && \
     apt-get clean
 RUN pwsh --version
 COPY requirements/sanity.ps1 /tmp/
-RUN /tmp/sanity.ps1 && rm /tmp/sanity.ps1
+RUN /tmp/sanity.ps1 -IsContainer && rm /tmp/sanity.ps1
 
 ENV container=docker
 CMD ["/sbin/init"]

--- a/requirements/sanity.ps1
+++ b/requirements/sanity.ps1
@@ -1,4 +1,9 @@
 #!/usr/bin/env pwsh
+param (
+    [Switch]
+    $IsContainer
+)
+
 #Requires -Version 6
 
 Set-StrictMode -Version 2.0
@@ -8,12 +13,14 @@ $ProgressPreference = 'SilentlyContinue'
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 Install-Module -Name PSScriptAnalyzer -RequiredVersion 1.18.0 -Scope CurrentUser
 
-# PSScriptAnalyzer contain lots of json files for the UseCompatibleCommands check. We don't use this rule so by
-# removing the contents we can save 200MB in the docker image (or more in the future).
-# https://github.com/PowerShell/PSScriptAnalyzer/blob/master/RuleDocumentation/UseCompatibleCommands.md
-$pssaPath = (Get-Module -ListAvailable -Name PSScriptAnalyzer).ModuleBase
-$compatPath = Join-Path -Path $pssaPath -ChildPath compatibility_profiles -AdditionalChildPath '*'
-Remove-Item -Path $compatPath -Recurse -Force
+if ($IsContainer) {
+    # PSScriptAnalyzer contain lots of json files for the UseCompatibleCommands check. We don't use this rule so by
+    # removing the contents we can save 200MB in the docker image (or more in the future).
+    # https://github.com/PowerShell/PSScriptAnalyzer/blob/master/RuleDocumentation/UseCompatibleCommands.md
+    $pssaPath = (Get-Module -ListAvailable -Name PSScriptAnalyzer).ModuleBase
+    $compatPath = Join-Path -Path $pssaPath -ChildPath compatibility_profiles -AdditionalChildPath '*'
+    Remove-Item -Path $compatPath -Recurse -Force
+}
 
 # Installed the PSCustomUseLiteralPath rule
 Install-Module -Name PSSA-PSCustomUseLiteralPath -RequiredVersion 0.1.1 -Scope CurrentUser


### PR DESCRIPTION
The sanity file was updated in https://github.com/ansible/ansible/pull/69992 to allow the same contents to be used by both ansible/ansible and the default container build. This updates the default-test-container to use the proper flags when running the sanity file.