### PR TITLE
Use Quay for base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM quay.io/bedrock/ubuntu:bionic-20201119
 
 # increment the number in this file to force a full container rebuild
 COPY files/update.txt /tmp/update.txt


### PR DESCRIPTION
Due to the new Docker Hub anonymous pull limits, use base images hosted in Quay.

Also switch to using date based tag.