### PR TITLE
Do not generate SSH client keys.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,6 @@ RUN apt-get update -y && \
     && \
     apt-get clean
 
-RUN ssh-keygen -m PEM -q -t rsa -N '' -f /root/.ssh/id_rsa && \
-    cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
-    for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-
 RUN rm /etc/apt/apt.conf.d/docker-clean
 RUN locale-gen en_US.UTF-8
 VOLUME /sys/fs/cgroup /run/lock /run /tmp


### PR DESCRIPTION
This is now the responsibility of ansible-test.