### PR TITLE
Update and freeze requirements.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,7 @@ CMD ["/sbin/init"]
 
 ADD https://ansible-ci-files.s3.amazonaws.com/ansible-test/get-pip-9.0.3.py /tmp/get-pip-9.0.3.py
 ADD https://ansible-ci-files.s3.amazonaws.com/ansible-test/get-pip-20.3.4.py /tmp/get-pip-20.3.4.py
+ADD https://ansible-ci-files.s3.amazonaws.com/ansible-test/get-pip-21.0.1.py /tmp/get-pip-21.0.1.py
 
 COPY files/requirements.sh /tmp/
 COPY files/early-requirements.txt /tmp/

--- a/files/requirements.sh
+++ b/files/requirements.sh
@@ -49,7 +49,7 @@ fi
 
 echo "Using constraints file: ${constraints}"
 
-pip_version="20.3.4"
+pip_version="21.0.1"
 
 if [[ "${python_version}" = "2.6" ]]; then
     pip_version="9.0.3"

--- a/files/requirements.sh
+++ b/files/requirements.sh
@@ -78,6 +78,11 @@ pip_install=("${pip[@]}" install)
 pip_list=("${pip[@]}" list "--format=columns")
 pip_check=("${pip[@]}" check)
 
+if [[ "${python_version}" = "2.6" ]]; then
+    install_pip+=(--index https://d2c8fqinjk13kw.cloudfront.net/simple/)
+    pip_install+=(--index https://d2c8fqinjk13kw.cloudfront.net/simple/)
+fi
+
 if [[ "${python_version}" = "3.8" ]]; then
     install_pip+=(--no-warn-script-location)
     pip_install+=(--no-warn-script-location)

--- a/freeze/2.7.txt
+++ b/freeze/2.7.txt
@@ -2,7 +2,7 @@ apipkg==1.5
 appdirs==1.4.4
 atomicwrites==1.4.0
 attrs==20.3.0
-backports.functools-lru-cache==1.6.1
+backports.functools-lru-cache==1.6.3
 bcrypt==3.1.7
 certifi==2020.12.5
 cffi==1.14.5
@@ -49,11 +49,11 @@ requests-credssp==1.2.0
 requests-ntlm==1.1.0
 resolvelib==0.5.4
 scandir==1.10.0
-singledispatch==3.4.0.3
+singledispatch==3.6.1
 six==1.15.0
 typing==3.7.4.3
-urllib3==1.26.3
-virtualenv==20.4.2
+urllib3==1.26.4
+virtualenv==20.4.3
 wcwidth==0.2.5
 xmltodict==0.12.0
 zipp==1.2.0

--- a/freeze/3.5.txt
+++ b/freeze/3.5.txt
@@ -39,6 +39,6 @@ requests-ntlm==1.1.0
 resolvelib==0.5.4
 six==1.15.0
 toml==0.10.2
-urllib3==1.26.3
+urllib3==1.26.4
 xmltodict==0.12.0
 zipp==1.2.0

--- a/freeze/3.6.txt
+++ b/freeze/3.6.txt
@@ -11,7 +11,7 @@ cryptography==3.3.2
 docutils==0.16
 execnet==1.8.0
 idna==2.5
-importlib-metadata==3.4.0
+importlib-metadata==3.10.0
 iniconfig==1.1.1
 isort==5.7.0
 Jinja2==2.11.3
@@ -51,9 +51,9 @@ six==1.15.0
 toml==0.10.2
 typed-ast==1.4.2
 typing-extensions==3.7.4.3
-urllib3==1.26.3
+urllib3==1.26.4
 voluptuous==0.12.1
 wrapt==1.12.1
 xmltodict==0.12.0
 yamllint==1.26.0
-zipp==3.4.0
+zipp==3.4.1

--- a/freeze/3.7.txt
+++ b/freeze/3.7.txt
@@ -11,7 +11,7 @@ cryptography==3.3.2
 docutils==0.16
 execnet==1.8.0
 idna==2.5
-importlib-metadata==3.4.0
+importlib-metadata==3.10.0
 iniconfig==1.1.1
 isort==5.7.0
 Jinja2==2.11.3
@@ -51,9 +51,9 @@ six==1.15.0
 toml==0.10.2
 typed-ast==1.4.2
 typing-extensions==3.7.4.3
-urllib3==1.26.3
+urllib3==1.26.4
 voluptuous==0.12.1
 wrapt==1.12.1
 xmltodict==0.12.0
 yamllint==1.26.0
-zipp==3.4.0
+zipp==3.4.1

--- a/freeze/3.8.txt
+++ b/freeze/3.8.txt
@@ -49,7 +49,7 @@ semantic-version==2.8.5
 six==1.15.0
 toml==0.10.2
 typed-ast==1.4.2
-urllib3==1.26.3
+urllib3==1.26.4
 voluptuous==0.12.1
 wrapt==1.12.1
 xmltodict==0.12.0

--- a/freeze/3.9.txt
+++ b/freeze/3.9.txt
@@ -49,7 +49,7 @@ semantic-version==2.8.5
 six==1.15.0
 toml==0.10.2
 typed-ast==1.4.2
-urllib3==1.26.3
+urllib3==1.26.4
 voluptuous==0.12.1
 wrapt==1.12.1
 xmltodict==0.12.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -2,6 +2,7 @@ resolvelib >= 0.5.3, < 0.6.0  # keep in sync with `requirements.txt`
 coverage >= 4.5.1, < 5.0.0 ; python_version <  '3.7' # coverage 4.4 required for "disable_warnings" support but 4.5.1 needed for bug fixes, coverage 5.0+ incompatible
 coverage >= 4.5.2, < 5.0.0 ; python_version == '3.7' # coverage 4.5.2 fixes bugs in support for python 3.7, coverage 5.0+ incompatible
 coverage >= 4.5.4, < 5.0.0 ; python_version >  '3.7' # coverage had a bug in < 4.5.4 that would cause unit tests to hang in Python 3.8, coverage 5.0+ incompatible
+six < 1.14.0 ; python_version < '2.7' # six 1.14.0 drops support for python 2.6
 cryptography < 2.2 ; python_version < '2.7' # cryptography 2.2 drops support for python 2.6
 cryptography < 3.4 ; python_version >= '2.7' # limit cryptography to the latest version ansible-test will accept
 # do not add a cryptography constraint here unless it is for python version incompatibility, see the get_cryptography_requirement function in executor.py for details

--- a/requirements/sanity.import-plugins.txt
+++ b/requirements/sanity.import-plugins.txt
@@ -1,0 +1,13 @@
+# Note: this requirements.txt file is used to specify what dependencies are
+# needed to make the package run rather than for deployment of a tested set of
+# packages.  Thus, this should be the loosest set possible (only required
+# packages, not optional ones, and with the widest range of versions that could
+# be suitable)
+jinja2
+PyYAML
+cryptography
+packaging
+# NOTE: resolvelib 0.x version bumps should be considered major/breaking
+# NOTE: and we should update the upper cap with care, at least until 1.0
+# NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
+resolvelib >= 0.5.3, < 0.6.0  # dependency resolver used by ansible-galaxy


### PR DESCRIPTION
This update includes the use of a separate package index for Python 2.6 since PyPI is dropping support for non-SNI clients.

It also includes an updated pip version for Python 3.6 and later, to bring in an updated setuptools. This resolves issues with installation of the lazy-object-proxy module.