### PR TITLE
Do not overwrite /usr/bin/python3.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,6 @@ RUN locale-gen en_US.UTF-8
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
 
 RUN ln -s python2.7 /usr/bin/python2
-RUN ln -s python3.9 /usr/bin/python3 -f
 RUN ln -s python3   /usr/bin/python
 
 # Install pwsh, and other PS/.NET sanity test tools.

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ COPY freeze/*.txt /tmp/freeze/
 RUN /tmp/requirements.sh 2.6
 RUN /tmp/requirements.sh 2.7
 RUN /tmp/requirements.sh 3.5
-RUN /tmp/requirements.sh 3.6
 RUN /tmp/requirements.sh 3.7
 RUN /tmp/requirements.sh 3.8
 RUN /tmp/requirements.sh 3.9
+RUN /tmp/requirements.sh 3.6


### PR DESCRIPTION
This fixes `python3-apt`, which requires `/usr/bin/python3` be Python 3.6.

Resolves https://github.com/ansible/default-test-container/issues/59