### PR TITLE
Drop trailing slash from GH URL.

### DIFF
--- a/update.py
+++ b/update.py
@@ -26,7 +26,7 @@ def main() -> None:
     with open('files/ansible-test-ref.txt', 'w') as file:
         file.write(f'{ref}\n')
 
-    with urllib.request.urlopen(f'https://api.github.com/repos/ansible/ansible/contents/test/lib/ansible_test/_data/requirements/?ref={ref}') as response:
+    with urllib.request.urlopen(f'https://api.github.com/repos/ansible/ansible/contents/test/lib/ansible_test/_data/requirements?ref={ref}') as response:
         files = json.loads(response.read().decode())
 
     requirements_dir = 'requirements'


### PR DESCRIPTION
The trailing slash causes a redirect which does not preserve the provided query string.