### PR TITLE
Add primitive wheel pre-build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ansible/base-test-container:5.1.0
+FROM quay.io/ansible/base-test-container:5.2.0
 
 COPY requirements /usr/share/container-setup/default/requirements/
 COPY freeze /usr/share/container-setup/default/freeze/
@@ -6,10 +6,7 @@ COPY freeze /usr/share/container-setup/default/freeze/
 RUN pwsh /usr/share/container-setup/default/requirements/sanity.pslint.ps1 -IsContainer && \
     rm -rf /tmp/.dotnet /tmp/Microsoft.PackageManagement
 
-RUN cd /tmp && echo 'Cython < 3' > constraints.txt && \
-    PIP_CONSTRAINT=/tmp/constraints.txt python2.7 -m pip install pyyaml==5.4.1 && \
-    rm -r constraints.txt /root/.cache/pip
-
+COPY files/pre-build /usr/share/container-setup/pre-build/
 COPY files/requirements.py /usr/share/container-setup/
 RUN /usr/share/container-setup/python -B /usr/share/container-setup/requirements.py default
 

--- a/files/pre-build/2.7.txt
+++ b/files/pre-build/2.7.txt
@@ -1,0 +1,2 @@
+# pre-build requirement: pyyaml == 5.4.1
+# pre-build constraint: Cython < 3

--- a/files/prime.py
+++ b/files/prime.py
@@ -91,7 +91,7 @@ def setup_sanity_venvs(context: str) -> None:
 
     display.section('Cleaning Up')
     shutil.rmtree(base_directory)
-    shutil.rmtree(os.path.expanduser('~/.cache/pip'))
+    Pip.purge_cache()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The syntax used is compatible with that currently used in ansible-test.

However, due to the limitations of the current pre-build syntax, a separate file is needed for each Python version. A future implementation will hopefully support the necessary syntax inline in the existing requirements files.